### PR TITLE
Basic benchmark script for a very simple kernel loop

### DIFF
--- a/benchmark_kernelloop.py
+++ b/benchmark_kernelloop.py
@@ -1,0 +1,37 @@
+import numpy as np
+import parcels
+
+runtime = np.timedelta64(10, "D")
+dt = np.timedelta64(30, "m")
+
+parcelsv4 = True
+try:
+    from parcels._datasets.structured.generic import datasets as datasets_structured
+except ImportError:
+    from tests.utils import create_fieldset_zeros_unit_mesh
+    parcelsv4 = False
+
+# create fieldset
+if parcelsv4:
+    ds = datasets_structured["ds_2d_left"]
+    grid = parcels.xgrid.XGrid(parcels.xgcm.Grid(ds))
+    U = parcels.Field("U", ds["U (A grid)"], grid, mesh_type="flat")
+    V = parcels.Field("V", ds["V (A grid)"], grid, mesh_type="flat")
+    fieldset = parcels.FieldSet([U, V])
+else:
+    fieldset = create_fieldset_zeros_unit_mesh()
+
+pclass = parcels.Particle if parcelsv4 else parcels.JITParticle
+
+# use a kernel that doesn't involve field access/interpolation
+def DoNothing(particle, fieldset, time):
+    pass
+
+for npart in [1, 10, 100, 1000]:
+    lon = np.linspace(-10, 10, npart)
+    lat = np.linspace(-30, -20, npart)
+
+    pset = parcels.ParticleSet(fieldset=fieldset, pclass=pclass, lon=lon, lat=lat)
+
+    print(f"Running {len(lon)} particles with parcels v{4 if parcelsv4 else 3}")
+    pset.execute(DoNothing, runtime=runtime, dt=dt)


### PR DESCRIPTION
A first, very simple script, that can be used for benchmarking the Kernel-loop itself. Since the Kernel is doing nothing, there is no field access or call to interpolation methods. 

With the current commit of v4-dev (488e3fb71e39414a2511510ee9555ff3e2763d1c), the scaling is pretty poor. 

The timing on my machine for the `pset.execute()` for `npart=1, 10, 100, 1000 and 2500` particles is 0:01, 0:10, 1:36, 15:48 and 37:57 minutes, respectively. That's a nicely linear scaling, but of course not at all efficient

For `main` (i.e. Parcels v3), the `pset.execute()` for all values of `npart` are taking 0 seconds, irrespective of number of particles

I'll start digging in to get this poor scaling of the Kernel/pset.execute() loop with particle size and hopefully find an improvement soon
