### PR TITLE
Adding benchmark test for CopernicusMarine with different Interpolators

### DIFF
--- a/CopernicusMarineService/benchmark_CopernicusMarineService.py
+++ b/CopernicusMarineService/benchmark_CopernicusMarineService.py
@@ -1,0 +1,139 @@
+from argparse import ArgumentParser
+from pathlib import Path
+import xarray as xr
+
+from glob import glob
+
+import numpy as np
+
+import parcels
+
+runtime = np.timedelta64(10, "D")
+dt = np.timedelta64(3, "h")
+
+parcelsv4 = True
+try:
+    from parcels.xgrid import _XGRID_AXES
+except ImportError:
+    parcelsv4 = False
+
+DATA_ROOT = "/storage/shared/oceanparcels/input_data/CopernicusMarineService/GLOBAL_ANALYSIS_FORECAST_PHY_001_024_SMOC/"
+
+def run_benchmark(interpolator: str):
+    if parcelsv4:
+
+        def BiRectiLinear(
+            field: parcels.Field,
+            ti: int,
+            position: dict[_XGRID_AXES, tuple[int, float | np.ndarray]],
+            tau: np.float32 | np.float64,
+            t: np.float32 | np.float64,
+            z: np.float32 | np.float64,
+            y: np.float32 | np.float64,
+            x: np.float32 | np.float64,
+        ):
+            """Bilinear interpolation on a rectilinear grid."""
+            xi, xsi = position["X"]
+            yi, eta = position["Y"]
+            zi, zeta = position["Z"]
+
+            data = field.data.isel({"time": slice(ti, ti + 2), "lat": slice(yi, yi + 2), "lon": slice(xi, xi + 2)}).data#.compute()
+            val_t0 =(
+                (1 - xsi) * (1 - eta) * data[0, 0, 0, 0]
+                + xsi * (1 - eta) * data[0, 0, 0, 1]
+                + xsi * eta * data[0, 0, 1, 1]
+                + (1 - xsi) * eta * data[0, 0, 1, 0]
+            )
+
+            val_t1 =(
+                (1 - xsi) * (1 - eta) * data[1, 0, 0, 0]
+                + xsi * (1 - eta) * data[1, 0, 0, 1]
+                + xsi * eta * data[1, 0, 1, 1]
+                + (1 - xsi) * eta * data[1, 0, 1, 0]
+            )
+            return (val_t0 * (1 - tau) + val_t1 * tau)
+
+        def PureXarrayInterp(
+            field: parcels.Field,
+            ti: int,
+            position: dict[_XGRID_AXES, tuple[int, float | np.ndarray]],
+            tau: np.float32 | np.float64,
+            t: np.float32 | np.float64,
+            z: np.float32 | np.float64,
+            y: np.float32 | np.float64,
+            x: np.float32 | np.float64,
+        ):
+            return field.data.interp(time=t, lon=x, lat=y).values[0]
+
+
+        def NoFieldAccess(
+            field: parcels.Field,
+            ti: int,
+            position: dict[_XGRID_AXES, tuple[int, float | np.ndarray]],
+            tau: np.float32 | np.float64,
+            t: np.float32 | np.float64,
+            z: np.float32 | np.float64,
+            y: np.float32 | np.float64,
+            x: np.float32 | np.float64,
+        ):
+            return 0
+
+
+    files = f"{DATA_ROOT}/SMOC_202101*.nc"
+
+    if parcelsv4:
+        if interpolator == "BiRectiLinear":
+            interp_method = BiRectiLinear
+        elif interpolator == "PureXarrayInterp":
+            interp_method = PureXarrayInterp
+        elif interpolator == "NoFieldAccess":
+            interp_method = NoFieldAccess
+        else:
+            raise ValueError(f"Unknown interpolator: {interpolator}")
+        ds = xr.open_mfdataset(files, concat_dim="time", combine="nested", data_vars='minimal', coords='minimal', compat='override')
+        ds = ds.rename({"uo": "U", "vo": "V", "longitude": "lon", "latitude": "lat"})
+
+        xgcm_grid = parcels.xgcm.Grid(ds, coords={"X": {"left": "lon"}, "Y": {"left": "lat"}, "Z": {"left": "depth"}, "T": {"center": "time"}})
+        grid = parcels.xgrid.XGrid(xgcm_grid)
+
+        U = parcels.Field("U", ds["U"], grid, interp_method=interp_method)
+        V = parcels.Field("V", ds["V"], grid, interp_method=interp_method)
+        U.units = parcels.GeographicPolar()
+        V.units = parcels.Geographic()
+        UV = parcels.VectorField("UV", U, V)
+
+        fieldset = parcels.FieldSet([U, V, UV])
+    else:
+        interpolator = "v3_default"
+        fieldset = parcels.FieldSet.from_netcdf(files, variables={"U": "uo", "V": "vo"}, dimensions={"time": "time", "lat": "latitude", "lon": "longitude", "depth": "depth"})
+
+    pclass = parcels.Particle if parcelsv4 else parcels.JITParticle
+
+    kernel = parcels.AdvectionEE
+
+    for npart in [1, 10, 30, 50]:
+        lon = np.linspace(-10, 10, npart)
+        lat = np.linspace(-30, -20, npart)
+
+        pset = parcels.ParticleSet(fieldset=fieldset, pclass=pclass, lon=lon, lat=lat)
+
+        print(f"Running {len(lon)} particles with parcels v{4 if parcelsv4 else 3} and {interpolator} interpolator")
+        pset.execute(kernel, runtime=runtime, dt=dt)
+
+
+def main(args=None):
+    p = ArgumentParser()
+
+    p.add_argument(
+        "-i",
+        "--Interpolator",
+        choices=("BiRectiLinear", "PureXarrayInterp", "NoFieldAccess"),
+        default="BiRectiLinear",
+    )
+
+    args = p.parse_args(args)
+    run_benchmark(args.Interpolator)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR adds a benchmark test for the CopernicusMarineService data (specifically the SMOC product). The aim is to explore the scaling of the interpolation / field-evaluation loop. 

The script in this PR was run with either Parcels-`main` (for the v3-benmarking) or with https://github.com/OceanParcels/Parcels/pull/2098 (for the v4-benchmarking

The good news is that for 1 particle, v4 is faster than v3. However, the (more important) not-so-good-news is that the scaling for v4 is _much_ worse than v3. See figure below
<img width="657" height="362" alt="Screenshot 2025-07-21 at 17 05 16" src="https://github.com/user-attachments/assets/9c99694e-09db-45d6-a5ae-51d1b5ebaad5" />

1. For these small amounts of particles (≤50), the timing for v3 is constant and independent of JIT (blue) or Scipy (red) mode at approximately 2 minutes; suggesting that (almost) all compute time goes into reading the FieldSet

For the current v4, however, the runtime depends strongly on the type of interpolation methods.

2. Using the `PureXarrayInterp` method defined in this PR (simply `return field.data.interp(time=t, lon=x, lat=y).values[0]`) gives the slowest runtime for `npart=50` (more than 30 minutes; yellow line)

3. Using the explicit `BiRectiLinear` method defined in this PR approximately halves the runtime (green line)

4. However, using the `NoFieldAccess` method defined in this PR (simply `return 0` without any xarray access to the field data; but with index_searching) is blazingly fast (only 2 seconds for `npart=50`, the hardly-visible orange line at the bottom of the figure)

So, this suggests that the bottleneck is the access to `field.data` in the Interpolators. It's likely that our access pattern (one particle at a time) is just not efficient now. We'll need to consider how to make this access pattern smarter...
