### PR TITLE
Benchmark MOi curvilinear

### DIFF
--- a/MOi-Curvilinear/benchmark_moi_curvilinear.py
+++ b/MOi-Curvilinear/benchmark_moi_curvilinear.py
@@ -16,8 +16,7 @@ dt = np.timedelta64(15, "m")
 parcelsv4 = True
 try:
     import xgcm
-    from parcels.xgrid import _XGRID_AXES
-    from parcels.application_kernels.interpolation import XLinear
+    from parcels.interpolators import XLinear
 except ImportError:
     parcelsv4 = False
 
@@ -76,7 +75,7 @@ def run_benchmark(interpolator: str, trace_memory: bool = False, surface_simulat
                 coords["Z"] = {"center": "deptht", "left": "depth"}
             print(ds)
 
-            grid = parcels.xgrid.XGrid(xgcm.Grid(ds, coords=coords, autoparse_metadata=False, periodic=False), mesh="spherical")
+            grid = parcels._core.xgrid.XGrid(xgcm.Grid(ds, coords=coords, autoparse_metadata=False, periodic=False), mesh="spherical")
 
             U = parcels.Field("U", ds["U"], grid, interp_method=interp_method)
             V = parcels.Field("V", ds["V"], grid, interp_method=interp_method)
@@ -127,7 +126,7 @@ def run_benchmark(interpolator: str, trace_memory: bool = False, surface_simulat
             else:
                 start = time.time()
 
-            pset.execute(parcels.AdvectionEE, runtime=runtime, dt=dt, verbose_progress=False)
+            pset.execute(parcels.kernels.AdvectionEE, runtime=runtime, dt=dt, verbose_progress=False)
 
             if trace_memory:
                 current, peak = tracemalloc.get_traced_memory()


### PR DESCRIPTION
This PR benchmarks a "real-life" simulation on the curvilinear 1/12degree global NEMO data as distributed by MOi. There's an option for both a surface run (where only the surface fields are used; so less I/O) or a full 3D run. Benchmarks are discussed in the comments below