### PR TITLE
[DRAFT] Feature/gather machine specs

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -16,5 +16,7 @@ parcels = "=4.0.0alpha1"
 xarray = ">=2025.09.0"
 uxarray = ">=2025.09.0"
 pooch = ">=1.8.2"
+platform = "1.0.8"
+psutil = "7.0.0"
 
 pre_commit = "*"

--- a/util/machine.py
+++ b/util/machine.py
@@ -1,0 +1,63 @@
+
+
+import platform
+from numpy import rint
+import psutil
+import cpuinfo
+import subprocess
+import json
+
+
+def get_cpuinfo():
+    info = {}
+    info["cpu"] = {}
+    info["cpu"]["architecture"] = platform.processor()
+    info["cpu"]["model"] = cpuinfo.get_cpu_info().get('brand_raw', 'unknown')
+    info["cpu"]["count"] = psutil.cpu_count(logical=False)
+    info["cpu"]["count_logical"] = psutil.cpu_count(logical=True)
+    info["cpu"]["freq_MHz"] = psutil.cpu_freq().max
+    return info
+
+def get_meminfo():
+    info = {}
+    try:
+        out = subprocess.check_output(["sudo", "lshw", "-C", "memory", "-json"], stderr=subprocess.STDOUT, text=True)
+        info['memory'] = json.loads(out)
+                
+    except Exception:
+        info = {}
+
+    return info
+
+def get_diskinfo():
+    info = {}
+    try:
+        out = subprocess.check_output(["sudo", "lshw", "-C", "disk", "-json"], stderr=subprocess.STDOUT, text=True)
+        info['disk'] = json.loads(out)
+                
+    except Exception:
+        info['disk'] = {}
+
+    return info
+
+def get_machine():
+
+    machine = {}
+
+    # OS Information
+    machine["system"] = platform.system()
+    machine["release"] = platform.release()
+    machine["name"] = platform.node()
+    # CPU information
+    machine.update(get_cpuinfo())
+    # Memory information
+    machine.update(get_meminfo())
+    # Disk information
+    machine.update(get_diskinfo())
+    
+    return machine
+    
+
+if __name__ == "__main__":
+    info = get_machine()
+    print(json.dumps(info, indent=2))

--- a/util/machine.py
+++ b/util/machine.py
@@ -1,12 +1,10 @@
 
 
 import platform
-from numpy import rint
 import psutil
 import cpuinfo
 import subprocess
 import json
-
 
 def get_cpuinfo():
     info = {}


### PR DESCRIPTION
This PR adds a utility to gather machine specs.
Note that the memory and disk details require `dmidecode` and `lshw` with root priviliges.

Not all the details are necessary and I can easily trim back on the number of details to only those that are relevant. This way, if the tool can't gather them (e.g. if someone is on a HPC cluster or they don't have admin privileges on their platform) they can still fill them in manually without being overwhelmed with the number of attributes.


## Example machine specs
This is an example of the machine specs gathered on linux.
```
{
  "system": "Linux",
  "release": "5.14.0-570.42.2.el9_6.x86_64",
  "name": "claymation",
  "cpu": {
    "architecture": "x86_64",
    "model": "12th Gen Intel(R) Core(TM) i5-1235U",
    "count": 10,
    "count_logical": 12,
    "freq_MHz": 3666.6666666666665
  },
  "memory": [
    {
      "id": "firmware",
      "class": "memory",
      "claimed": true,
      "description": "BIOS",
      "vendor": "coreboot",
      "physid": "0",
      "version": "2023-09-08_42bf7a6",
      "date": "09/08/2023",
      "units": "bytes",
      "size": 1048576,
      "capacity": 33554432,
      "capabilities": {
        "pci": "PCI bus",
        "pcmcia": "PCMCIA/PCCard",
        "upgrade": "BIOS EEPROM can be upgraded",
        "bootselect": "Selectable boot path",
        "acpi": "ACPI"
      }
    },
    {
      "id": "cache:0",
      "class": "memory",
      "claimed": true,
      "handle": "DMI:0006",
      "description": "L1 cache",
      "physid": "6",
      "slot": "CACHE1",
      "units": "bytes",
      "size": 196608,
      "capacity": 196608,
      "configuration": {
        "level": "1"
      },
      "capabilities": {
        "internal": "Internal",
        "instruction": "Instruction cache"
      }
    },
    {
      "id": "cache:1",
      "class": "memory",
      "claimed": true,
      "handle": "DMI:0007",
      "description": "L2 cache",
      "physid": "7",
      "slot": "CACHE2",
      "units": "bytes",
      "size": 1310720,
      "capacity": 1310720,
      "configuration": {
        "level": "2"
      },
      "capabilities": {
        "internal": "Internal",
        "unified": "Unified cache"
      }
    },
    {
      "id": "cache:2",
      "class": "memory",
      "claimed": true,
      "handle": "DMI:0008",
      "description": "L3 cache",
      "physid": "8",
      "slot": "CACHE3",
      "units": "bytes",
      "size": 12582912,
      "capacity": 12582912,
      "configuration": {
        "level": "3"
      },
      "capabilities": {
        "internal": "Internal",
        "unified": "Unified cache"
      }
    },
    {
      "id": "cache",
      "class": "memory",
      "claimed": true,
      "handle": "DMI:0005",
      "description": "L1 cache",
      "physid": "5",
      "slot": "CACHE1",
      "units": "bytes",
      "size": 294912,
      "capacity": 294912,
      "configuration": {
        "level": "1"
      },
      "capabilities": {
        "internal": "Internal",
        "data": "Data cache"
      }
    },
    {
      "id": "memory",
      "class": "memory",
      "claimed": true,
      "handle": "DMI:0009",
      "description": "System Memory",
      "physid": "9",
      "slot": "System board or motherboard",
      "units": "bytes",
      "size": 17179869184
    },
    {
      "id": "bank:0",
      "class": "memory",
      "claimed": true,
      "handle": "DMI:000A",
      "description": "SODIMM DDR4 Synchronous 3200 MHz (0.3 ns)",
      "product": "P4AAF165WA-BCWDE",
      "vendor": "Samsung",
      "physid": "0",
      "serial": "00000000",
      "slot": "Channel-0-DIMM-0",
      "units": "bytes",
      "size": 8589934592,
      "width": 64,
      "clock": 3200000000
    },
    {
      "id": "bank:1",
      "class": "memory",
      "claimed": true,
      "handle": "DMI:000B",
      "description": "SODIMM DDR4 Synchronous 3200 MHz (0.3 ns)",
      "product": "P4AAF165WA-BCWDE",
      "vendor": "Unknown (4589)",
      "physid": "1",
      "serial": "02083201",
      "slot": "Channel-0-DIMM-0",
      "units": "bytes",
      "size": 8589934592,
      "width": 64,
      "clock": 3200000000
    },
    {
      "id": "memory",
      "class": "memory",
      "handle": "PCI:0000:00:14.2",
      "description": "RAM memory",
      "product": "Alder Lake PCH Shared SRAM",
      "vendor": "Intel Corporation",
      "physid": "14.2",
      "businfo": "pci@0000:00:14.2",
      "version": "01",
      "width": 64,
      "clock": 33000000,
      "configuration": {
        "latency": "0"
      },
      "capabilities": {
        "pm": "Power Management",
        "bus_master": "bus mastering",
        "cap_list": "PCI capabilities listing"
      }
    }
  ],
  "disk": [
    {
      "id": "namespace:0",
      "class": "disk",
      "claimed": true,
      "description": "NVMe disk",
      "physid": "0",
      "logicalname": "/dev/ng1n1"
    },
    {
      "id": "namespace:1",
      "class": "disk",
      "claimed": true,
      "handle": "GUID:6258d613-b914-4468-a89d-5362e66263b5",
      "description": "NVMe disk",
      "physid": "1",
      "businfo": "nvme@1:1",
      "logicalname": "/dev/nvme1n1",
      "units": "bytes",
      "size": 500107862016,
      "configuration": {
        "guid": "6258d613-b914-4468-a89d-5362e66263b5",
        "logicalsectorsize": "512",
        "sectorsize": "512",
        "wwid": "eui.e8238fa6bf530001001b448b4bf2e703"
      },
      "capabilities": {
        "gpt-1.00": "GUID Partition Table version 1.00",
        "partitioned": "Partitioned disk",
        "partitioned:gpt": "GUID partition table"
      }
    },
    {
      "id": "namespace:0",
      "class": "disk",
      "claimed": true,
      "description": "NVMe disk",
      "physid": "0",
      "logicalname": "/dev/ng0n1"
    },
    {
      "id": "namespace:1",
      "class": "disk",
      "claimed": true,
      "description": "NVMe disk",
      "physid": "1",
      "businfo": "nvme@0:1",
      "logicalname": "/dev/nvme0n1",
      "units": "bytes",
      "size": 2000398934016,
      "configuration": {
        "logicalsectorsize": "512",
        "sectorsize": "512",
        "signature": "b93f07ad",
        "wwid": "eui.e8238fa6bf530001001b448b474c37f5"
      },
      "capabilities": {
        "partitioned": "Partitioned disk",
        "partitioned:dos": "MS-DOS partition table"
      }
    }
  ]
}
```