### PR TITLE
Define single function for particle forward stepping

### DIFF
--- a/benchmarks/fesom2.py
+++ b/benchmarks/fesom2.py
@@ -45,7 +45,7 @@ class FESOM2:
             u = ds["u"].isel(time=i).compute()
             v = ds["v"].isel(time=i).compute()
 
-    def time_pset_execute(self,npart,integrator):
+    def pset_execute(self,npart,integrator):
         ds = _load_ds(self.datapath)
         grid = UxGrid(ds.uxgrid, z=ds.coords["nz"], mesh="flat")
         U = Field(name="U", data=ds.u, grid=grid, interp_method=UxPiecewiseConstantFace)
@@ -60,19 +60,9 @@ class FESOM2:
 
         pset = ParticleSet(fieldset=fieldset, pclass=Particle, lon=lon, lat=lat)
         pset.execute(runtime=runtime, dt=dt, pyfunc=integrator)
+
+    def time_pset_execute(self,npart,integrator):
+        self.pset_execute(npart,integrator)
 
     def peakmem_pset_execute(self,npart,integrator):
-        ds = _load_ds(self.datapath)
-        grid = UxGrid(ds.uxgrid, z=ds.coords["nz"], mesh="flat")
-        U = Field(name="U", data=ds.u, grid=grid, interp_method=UxPiecewiseConstantFace)
-        V = Field(name="V", data=ds.v, grid=grid, interp_method=UxPiecewiseConstantFace)
-        U.units = GeographicPolar()
-        V.units = Geographic()
-        UV = VectorField(name="UV", U=U, V=V) 
-        fieldset = FieldSet([UV, UV.U, UV.V])
-
-        lon = np.linspace(2.0,15.0,npart)
-        lat = np.linspace(32.0,19.0,npart)
-
-        pset = ParticleSet(fieldset=fieldset, pclass=Particle, lon=lon, lat=lat)
-        pset.execute(runtime=runtime, dt=dt, pyfunc=integrator)
+        self.pset_execute(npart,integrator)

--- a/benchmarks/moi_curvilinear.py
+++ b/benchmarks/moi_curvilinear.py
@@ -65,71 +65,42 @@ class MOICurvilinear:
                 v = ds["V"].isel(deptht=j,time=i).compute()
 
 
+    def pset_execute_3d(self,interpolator,chunk,npart):
+        ds = _load_ds(self.datapath,chunk)
+        coords={
+            "X": {"left": "x"},
+            "Y": {"left": "y"},
+            "Z": {"center": "deptht", "left": "depth"},
+            "T": {"center": "time"},
+        }
+
+        grid = parcels._core.xgrid.XGrid(xgcm.Grid(ds, coords=coords, autoparse_metadata=False, periodic=False), mesh="spherical")
+
+        if interpolator == "XLinear":
+            interp_method = XLinear
+        else:
+            raise ValueError(f"Unknown interpolator: {interpolator}")
+
+        U = parcels.Field("U", ds["U"], grid, interp_method=interp_method)
+        V = parcels.Field("V", ds["V"], grid, interp_method=interp_method)
+        U.units = parcels.GeographicPolar()
+        V.units = parcels.Geographic()
+        UV = parcels.VectorField("UV", U, V)
+    
+        fieldset = parcels.FieldSet([U, V, UV])
+    
+        pclass = parcels.Particle
+
+        lon = np.linspace(-10, 10, npart)
+        lat = np.linspace(-30, -20, npart)
+
+        pset = parcels.ParticleSet(fieldset=fieldset, pclass=pclass, lon=lon, lat=lat)
+
+        pset.execute(parcels.kernels.AdvectionEE, runtime=runtime, dt=dt, verbose_progress=False)
+
     def time_pset_execute_3d(self,interpolator,chunk,npart):
+        self.pset_execute_3d(interpolator,chunk,npart)
 
-        ds = _load_ds(self.datapath,chunk)
-        coords={
-            "X": {"left": "x"},
-            "Y": {"left": "y"},
-            "Z": {"center": "deptht", "left": "depth"},
-            "T": {"center": "time"},
-        }
-
-        grid = parcels._core.xgrid.XGrid(xgcm.Grid(ds, coords=coords, autoparse_metadata=False, periodic=False), mesh="spherical")
-
-        if interpolator == "XLinear":
-            interp_method = XLinear
-        else:
-            raise ValueError(f"Unknown interpolator: {interpolator}")
-
-        U = parcels.Field("U", ds["U"], grid, interp_method=interp_method)
-        V = parcels.Field("V", ds["V"], grid, interp_method=interp_method)
-        U.units = parcels.GeographicPolar()
-        V.units = parcels.Geographic()
-        UV = parcels.VectorField("UV", U, V)
-    
-        fieldset = parcels.FieldSet([U, V, UV])
-    
-        pclass = parcels.Particle
-
-        lon = np.linspace(-10, 10, npart)
-        lat = np.linspace(-30, -20, npart)
-
-        pset = parcels.ParticleSet(fieldset=fieldset, pclass=pclass, lon=lon, lat=lat)
-
-        pset.execute(parcels.kernels.AdvectionEE, runtime=runtime, dt=dt, verbose_progress=False)
-        
     def peakmem_pset_execute_3d(self,interpolator,chunk,npart):
+        self.pset_execute_3d(interpolator,chunk,npart)
 
-
-        ds = _load_ds(self.datapath,chunk)
-        coords={
-            "X": {"left": "x"},
-            "Y": {"left": "y"},
-            "Z": {"center": "deptht", "left": "depth"},
-            "T": {"center": "time"},
-        }
-
-        grid = parcels._core.xgrid.XGrid(xgcm.Grid(ds, coords=coords, autoparse_metadata=False, periodic=False), mesh="spherical")
-
-        if interpolator == "XLinear":
-            interp_method = XLinear
-        else:
-            raise ValueError(f"Unknown interpolator: {interpolator}")
-
-        U = parcels.Field("U", ds["U"], grid, interp_method=interp_method)
-        V = parcels.Field("V", ds["V"], grid, interp_method=interp_method)
-        U.units = parcels.GeographicPolar()
-        V.units = parcels.Geographic()
-        UV = parcels.VectorField("UV", U, V)
-    
-        fieldset = parcels.FieldSet([U, V, UV])
-    
-        pclass = parcels.Particle
-
-        lon = np.linspace(-10, 10, npart)
-        lat = np.linspace(-30, -20, npart)
-
-        pset = parcels.ParticleSet(fieldset=fieldset, pclass=pclass, lon=lon, lat=lat)
-
-        pset.execute(parcels.kernels.AdvectionEE, runtime=runtime, dt=dt, verbose_progress=False)


### PR DESCRIPTION
This provides a single function for the pset_execute benchmarks. The `time_` and `peakmem_` functions that are consumed by ASV call the function. This improves code reuse and ensures consistency between the runtime and peak memory benchmark measurements.

Related to the discussion #25 