### PR TITLE
Fix interpolation error in MOI benchmark

### DIFF
--- a/benchmarks/moi_curvilinear.py
+++ b/benchmarks/moi_curvilinear.py
@@ -65,8 +65,9 @@ class MOICurvilinear:
 
         lon = np.linspace(-10, 10, npart)
         lat = np.linspace(-30, -20, npart)
+        z= np.ones(npart) * 10  # 10 m depth
 
-        pset = parcels.ParticleSet(fieldset=fieldset, pclass=pclass, lon=lon, lat=lat)
+        pset = parcels.ParticleSet(fieldset=fieldset, pclass=pclass, lon=lon, lat=lat, z=z)
 
         pset.execute(
             parcels.kernels.AdvectionEE, runtime=runtime, dt=dt, verbose_progress=False

--- a/benchmarks/moi_curvilinear.py
+++ b/benchmarks/moi_curvilinear.py
@@ -65,9 +65,11 @@ class MOICurvilinear:
 
         lon = np.linspace(-10, 10, npart)
         lat = np.linspace(-30, -20, npart)
-        z= np.ones(npart) * 10  # 10 m depth
+        z = np.ones(npart) * 10  # 10 m depth
 
-        pset = parcels.ParticleSet(fieldset=fieldset, pclass=pclass, lon=lon, lat=lat, z=z)
+        pset = parcels.ParticleSet(
+            fieldset=fieldset, pclass=pclass, lon=lon, lat=lat, z=z
+        )
 
         pset.execute(
             parcels.kernels.AdvectionEE, runtime=runtime, dt=dt, verbose_progress=False


### PR DESCRIPTION
The interpolation error was due to the particle.z not explicitly set, meaning that particles were released at z=0; which is out of the domain?