### PR TITLE
Add Buildkite pipeline for galapagos benchmark runs

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -6,6 +6,7 @@ steps:
       export PARCELS_BENCHMARKS_DATA_FOLDER="/apps/parcels-ci"
       pixi install
       pixi run setup-data
+      pixi run asv machine --yes
       pixi run asv run
 
     env:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,0 +1,19 @@
+steps:
+  - label: "Run all benchmarks (NVMe)"
+    key: "test-nvme"
+    command: |
+      # Sets the data directory to local NVMe scratch disk
+      export PARCELS_BENCHMARKS_DATA_FOLDER="/apps/parcels-ci"
+      pixi install
+      pixi run setup-data
+      pixi run asv run
+
+    env:
+      slurm_partition: "main"
+      slurm_time: "08:00:00"
+      slurm_nodes: 1
+      slurm_nodelist: "franklin"
+      slurm_ntasks_per_node: 1
+      slurm_cpus_per_task: 8
+    agents:
+      queue: "galapagos"


### PR DESCRIPTION
Adds a Buildkite pipeline step that runs the full benchmark suite on the galapagos queue (franklin node) using local scratch for the dataset.

The pipeline uses the actual pixi tasks and env var the benchmarks expect:
- PARCELS_BENCHMARKS_DATA_FOLDER (read by benchmarks/__init__.py)
- `pixi run setup-data` to download/extract the catalog data
- `pixi run asv run` to run the benchmarks