### PR TITLE
Copernicusmarine streaming performance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+**.parquet
+**.nc
+
 # pixi environments
 .pixi/*
 !.pixi/config.toml

--- a/benchmarks/copernicusstreaming.py
+++ b/benchmarks/copernicusstreaming.py
@@ -20,7 +20,7 @@ def run_copernicusmarine_benchmark(load_mode="as_file"):
         end_datetime="2024-01-31",
         minimum_depth=0.5,
         maximum_depth=5,
-        service = "arco-geo-series",
+        service="arco-geo-series",
         chunk_size_limit=1,
     )
     ds = parcels.convert.copernicusmarine_to_sgrid(

--- a/benchmarks/copernicusstreaming.py
+++ b/benchmarks/copernicusstreaming.py
@@ -1,0 +1,75 @@
+import copernicusmarine
+import parcels
+import xarray as xr
+import numpy as np
+import time
+import argparse
+
+def run_copernicusmarine_benchmark(load_mode="as_file"):
+    copernicusmarine.login()
+
+    ds = copernicusmarine.open_dataset(
+        dataset_id="cmems_mod_glo_phy-cur_anfc_0.083deg_P1D-m",
+        variables=["uo", "vo"],
+        minimum_longitude=-20,
+        maximum_longitude=20,
+        minimum_latitude=-20,
+        maximum_latitude=20,
+        start_datetime="2024-01-01",
+        end_datetime="2024-01-31",
+        minimum_depth=0.5,
+        maximum_depth=5,
+    )
+    ds = parcels.convert.copernicusmarine_to_sgrid(
+        fields={"U": ds["uo"], "V": ds["vo"]}
+    )
+
+    if load_mode == "as_file":
+        ds.to_netcdf("tmp.nc")
+        del(ds)
+        ds = xr.open_dataset("tmp.nc")
+    elif load_mode == "ds_load":
+        ds.load()
+
+    fieldset = parcels.FieldSet.from_sgrid_conventions(ds)
+
+    if load_mode == "streaming":
+        fieldset.to_windowed_arrays()
+
+    fieldset.describe()
+
+    pset = parcels.ParticleSet(fieldset, x=0, y=0, z=2)
+    oufile = parcels.ParticleFile(
+        "tmp.parquet",
+        outputdt=np.timedelta64(1, "D"),
+        mode="w",
+    )
+
+    pset.execute(
+        parcels.kernels.AdvectionRK2,
+        dt=np.timedelta64(1, "h"),
+        runtime=np.timedelta64(30, "D"),
+        output_file=oufile,
+    )
+
+    # check for correctness of the benchmark result
+    np.testing.assert_allclose(pset.x, -14.034891, atol=1e-2)
+    np.testing.assert_allclose(pset.y, -2.1642778, atol=1e-2)
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--load_mode",
+        choices=["as_file", "ds_load", "streaming"],
+        default="streaming",
+    )
+    args = parser.parse_args()
+
+    time_start = time.time()
+    run_copernicusmarine_benchmark(load_mode=args.load_mode)
+    time_end = time.time()
+    print(f"Elapsed time: {(time_end - time_start):.2f}s")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/copernicusstreaming.py
+++ b/benchmarks/copernicusstreaming.py
@@ -20,6 +20,8 @@ def run_copernicusmarine_benchmark(load_mode="as_file"):
         end_datetime="2024-01-31",
         minimum_depth=0.5,
         maximum_depth=5,
+        service = "arco-geo-series",
+        chunk_size_limit=1,
     )
     ds = parcels.convert.copernicusmarine_to_sgrid(
         fields={"U": ds["uo"], "V": ds["vo"]}

--- a/benchmarks/copernicusstreaming.py
+++ b/benchmarks/copernicusstreaming.py
@@ -5,6 +5,7 @@ import numpy as np
 import time
 import argparse
 
+
 def run_copernicusmarine_benchmark(load_mode="as_file"):
     copernicusmarine.login()
 
@@ -26,7 +27,7 @@ def run_copernicusmarine_benchmark(load_mode="as_file"):
 
     if load_mode == "as_file":
         ds.to_netcdf("tmp.nc")
-        del(ds)
+        del ds
         ds = xr.open_dataset("tmp.nc")
     elif load_mode == "ds_load":
         ds.load()
@@ -55,6 +56,7 @@ def run_copernicusmarine_benchmark(load_mode="as_file"):
     # check for correctness of the benchmark result
     np.testing.assert_allclose(pset.x, -14.034891, atol=1e-2)
     np.testing.assert_allclose(pset.y, -2.1642778, atol=1e-2)
+
 
 def main():
     parser = argparse.ArgumentParser()

--- a/pixi.toml
+++ b/pixi.toml
@@ -66,3 +66,4 @@ netcdf4 = ">=1.7.4,<2"
 #curl = "*" # for some reason SSL key signing wasn't working on Lorenz with this curl - instead use curl which is installed on the system
 proj = "*"
 ty = "*"
+copernicusmarine = ">=2.4.1,<3"


### PR DESCRIPTION
This PR adds a script to test the performance of directly streaming from the `copernicusmarine()` store. As also found in https://github.com/Parcels-code/virtualship/issues/357, directly accessing the data from there is _much_ slower than temporarily saving the data to local disk

A quick performance overview of the script here on my MacBook:
- **Running with `--load_mode as_file` takes 21 seconds**. In this case, the full DataSet is stored to a local netcdf file, and then loaded again. Note that it automatically loads as NumPy (probably because the file is only 256MB in size)
- **Running with `--load_mode ds_load` takes 20 seconds**. In this case, the full DataSet is not stored on disk but loaded directly in memory with a `ds.load()`
- **Running with `--load_mode streaming` takes 518 seconds**, even when we use `to_windowed_arrays()`. As this is the preferred way to stream data from CopernicusMarine (no need for temporary storage, and able to scale to much larger datasets than required here), the 25x slowdown is not acceptable.

Note 1: I've been able to reduce the **`--load_mode streaming` time to 142 seconds** in 7c5a0ac81fd959df8a74f4b35d9d1286c79ecec2, by setting the options `copernicusmarine.open_dataset(..., service="arco-geo-series", chunk_size_limit=1)`. This is inspired by a discussion at https://github.com/mercator-ocean/copernicus-marine-toolbox/issues/267

Note 2: I can get `--load_mode streaming` even faster (equivalent to `--load_mode ds_load`) by setting `chunk_size_limit=0`, but this disables dask altogether so will have a major memory footprint (as it bypasses the WindowedArrays)